### PR TITLE
feat: Node 22 dev runtime, node 24 support, drop bugsnag/js

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     ignore:
       - dependency-name: "@types/node"
         versions:
-          - ">=20"
+          - ">=22"
     commit-message:
       prefix: fix
       prefix-development: chore

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -18,11 +18,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript' ]
+        language: [ 'javascript-typescript', 'actions' ]
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -33,7 +33,7 @@ jobs:
       - run: npm test
         name: Run tests
 
-      - name: Publish code coverage
-        uses: paambaati/codeclimate-action@v9.0.0
-        env:
-          CC_TEST_REPORTER_ID: ${{ secrets.CODECLIMATE_COVERAGE_REPORTER }}
+      - uses: qltysh/qlty-action/coverage@v2
+        with:
+          token: {{secrets.QLTY_COVERAGE_TOKEN}}
+          files: coverage/lcov.info

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -11,13 +11,13 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [ 20.x, 22.x, latest ]
+        node-version: [ 20.x, 22.x, 24.x, latest ]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -24,11 +24,11 @@ jobs:
       - run: npm install
         name: Install dependencies
 
-      - run: npm run build
-        name: Build the TS
-
       - run: npm run lint
         name: Run Linter
+
+      - run: npm run build
+        name: Build the TS
 
       - run: npm test
         name: Run tests

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -35,5 +35,5 @@ jobs:
 
       - uses: qltysh/qlty-action/coverage@v2
         with:
-          token: {{secrets.QLTY_COVERAGE_TOKEN}}
+          token: ${{secrets.QLTY_COVERAGE_TOKEN}}
           files: coverage/lcov.info

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,14 +19,14 @@ jobs:
           release-type: node
           token: ${{ secrets.RELEASE_PLEASE_GITHUB_TOKEN }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: ${{ steps.release.outputs.release_created }}
 
-      - uses: actions/setup-node@v4
-        name: Use Node.js 20
+      - uses: actions/setup-node@v5
+        name: Use Node.js 22
         if: ${{ steps.release.outputs.release_created }}
         with:
-          node-version: 20
+          node-version: 22
           registry-url: 'https://registry.npmjs.org'
 
       - run: npm install --ignore-scripts

--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ fastify.get('/error', async (request, reply) => {
 
 ## Options
 
-| Parameter | Default Value                 | Description                                                   |
-|-----------|-------------------------------|---------------------------------------------------------------|
-| `apiKey`  | `process.env.BUGSNAG_API_KEY` | API Key obtained from Bugsnag dashboard project. **REQUIRED** |
+| Parameter | Default Value                 | Description                                      |
+|-----------|-------------------------------|--------------------------------------------------|
+| `apiKey`  | `process.env.BUGSNAG_API_KEY` | API Key obtained from Bugsnag dashboard project. |
 
 For additional options check the official documentation of Bugsnag
 [here](https://docs.bugsnag.com/platforms/javascript/configuration-options/).

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![CI workflow](https://github.com/ZigaStrgar/fastify-bugsnag/workflows/fastify-bugsnag-ci/badge.svg)
 [![Known Vulnerabilities](https://snyk.io/test/github/ZigaStrgar/fastify-bugsnag/badge.svg)](https://snyk.io/test/github/ZigaStrgar/fastify-bugsnag)
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](https://standardjs.com/)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/ad24873a9f9078ff0b04/test_coverage)](https://codeclimate.com/github/ZigaStrgar/fastify-bugsnag/test_coverage)
+[![Code Coverage](https://qlty.sh/gh/ZigaStrgar/projects/fastify-bugsnag/coverage.svg)](https://qlty.sh/gh/ZigaStrgar/projects/fastify-bugsnag)
 
 Easily send your application errors to [Bugsnag](https://bugsnag.com) from your [Fastify](https://www.fastify.io/)
 server.

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ the request data to the error. That includes `body`, `query` and `params` which 
 
 ## Compatibility
 
-|         | Version                                    |
-|---------|--------------------------------------------|
-| Fastify | `^5.x`                                     |
-| Bugsnag | `^8.0.0`                                   |
-| Node    | <code>^20.10.0 &#124;&#124; ^22.0.0</code> |
+|         | Version                                                           |
+|---------|-------------------------------------------------------------------|
+| Fastify | `^5.x`                                                            |
+| Bugsnag | `^8.0.0`                                                          |
+| Node    | <code>^20.10.0 &#124;&#124; ^22.11.0 &#124;&#124; >=24.0.0</code> |
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -46,30 +46,32 @@
   },
   "homepage": "https://github.com/ZigaStrgar/fastify-bugsnag#readme",
   "dependencies": {
-    "@bugsnag/js": "^8.0.0",
     "@bugsnag/node": "^8.0.0",
     "fastify-plugin": "^5.0.1"
   },
   "engines": {
-    "node": "^20.10.0||^22.0.0"
+    "node": "^20.10.0||^22.11.0||>=24.0.0"
   },
   "devDependencies": {
-    "@tsconfig/node20": "^20.1.4",
-    "@types/mocha": "^10.0.3",
-    "@types/node": "^20.16.9",
-    "@types/sinon": "^17.0.3",
+    "@tsconfig/node22": "^22.0.2",
+    "@types/mocha": "^10.0.10",
+    "@types/node": "^22.18.8",
+    "@types/sinon": "^17.0.4",
     "fastify": "^5.0.0",
-    "mocha": "^10.2.0",
+    "mocha": "^11.7.4",
     "nyc": "^17.1.0",
     "rimraf": "^6.0.1",
     "sinon": "^19.0.2",
     "snazzy": "^9.0.0",
-    "ts-mocha": "^10.0.0",
+    "ts-mocha": "^11.1.0",
     "ts-node": "^10.8.0",
     "ts-standard": "^12.0.0",
     "tsd": "^0.31.2",
     "tsup": "^8.3.0",
-    "typescript": "~5.6"
+    "typescript": "~5.9.3"
+  },
+  "peerDependencies": {
+    "@bugsnag/node": "^8.0.0"
   },
   "ts-standard": {
     "ignore": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ function obtainRequestAndMetadataInfo (request: FastifyRequest): RequestInfoWith
   }
 }
 
-function bugsnagPlugin (fastify: FastifyInstance, options: PluginOptions | undefined, done: (error?: Error) => void): void {
+function bugsnagPlugin (fastify: FastifyInstance, options: PluginOptions, done: (error?: Error) => void): void {
   Bugsnag.start(options)
 
   fastify.decorate('bugsnag', Bugsnag)
@@ -57,7 +57,7 @@ function bugsnagPlugin (fastify: FastifyInstance, options: PluginOptions | undef
   done()
 }
 
-export default fp<PluginOptions | undefined>(bugsnagPlugin, {
+export default fp<PluginOptions>(bugsnagPlugin, {
   fastify: '5.x',
   name: 'fastify-bugsnag',
   dependencies: ['@bugsnag/node']

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,5 +59,5 @@ function bugsnagPlugin (fastify: FastifyInstance, options: PluginOptions, done: 
 
 export default fp<PluginOptions>(bugsnagPlugin, {
   fastify: '5.x',
-  name: 'fastify-bugsnag',
+  name: 'fastify-bugsnag'
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import Bugsnag from '@bugsnag/js'
+import Bugsnag from '@bugsnag/node'
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
 import fp from 'fastify-plugin'
 
@@ -9,7 +9,7 @@ function extractRequestMetadata (request: FastifyRequest): RequestMetadata {
     body: request.body,
     clientIp: request?.ips?.[0] ?? request.ip,
     headers: request.raw.headers,
-    httpMethod: request.routeOptions.method,
+    httpMethod: request.routeOptions.method.toString(),
     params: request.params,
     path: request.routeOptions.url,
     query: request.query,
@@ -33,7 +33,7 @@ function obtainRequestAndMetadataInfo (request: FastifyRequest): RequestInfoWith
   }
 }
 
-function bugsnagPlugin (fastify: FastifyInstance, options: PluginOptions, done: (error?: Error) => void): void {
+function bugsnagPlugin (fastify: FastifyInstance, options: PluginOptions | undefined, done: (error?: Error) => void): void {
   Bugsnag.start(options)
 
   fastify.decorate('bugsnag', Bugsnag)
@@ -57,7 +57,8 @@ function bugsnagPlugin (fastify: FastifyInstance, options: PluginOptions, done: 
   done()
 }
 
-export default fp(bugsnagPlugin, {
+export default fp<PluginOptions | undefined>(bugsnagPlugin, {
   fastify: '5.x',
-  name: 'fastify-bugsnag'
+  name: 'fastify-bugsnag',
+  dependencies: ['@bugsnag/node']
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,5 +60,4 @@ function bugsnagPlugin (fastify: FastifyInstance, options: PluginOptions, done: 
 export default fp<PluginOptions>(bugsnagPlugin, {
   fastify: '5.x',
   name: 'fastify-bugsnag',
-  dependencies: ['@bugsnag/node']
 })

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,7 @@
-import type { Client, BrowserConfig } from '@bugsnag/js'
-import type { NodeConfig } from '@bugsnag/node'
+import type { NodeConfig, Client } from '@bugsnag/node'
 import type { FastifyRequest } from 'fastify'
 
-export type PluginOptions = NodeConfig | BrowserConfig
+export type PluginOptions = NodeConfig
 
 export interface RequestMetadata {
   body?: FastifyRequest['body']

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -1,4 +1,4 @@
-import { Client } from '@bugsnag/js'
+import { Client } from '@bugsnag/node'
 import fastify from 'fastify'
 import { expectType } from 'tsd'
 
@@ -7,7 +7,7 @@ import plugin from '../../src'
 const app = fastify()
 
 // eslint-disable-next-line @typescript-eslint/no-floating-promises
-app.register(plugin).ready()
+app.register(plugin, { apiKey: 'apiKey' }).ready()
 
 expectType<Client>(app.bugsnag)
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node22",
+  "extends": "@tsconfig/node22/tsconfig.json",
   "compilerOptions": {
     "allowJs": true,
     "moduleDetection": "force",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node20/tsconfig.json",
+  "extends": "@tsconfig/node22",
   "compilerOptions": {
     "allowJs": true,
     "moduleDetection": "force",
@@ -15,7 +15,6 @@
     "removeComments": true,
     "sourceMap": true,
     "noEmit": true,
-    "esModuleInterop": true
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
## Changes

* Support Node 24 in `engines`
* Runtime during development uses Node 22
* TSConfig for Node 22
* Updated various dependencies and GH Actions