### PR TITLE
ci: add permissions to gh action

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,4 +1,6 @@
 name: fastify-bugsnag-ci
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/ZigaStrgar/fastify-bugsnag/security/code-scanning/2](https://github.com/ZigaStrgar/fastify-bugsnag/security/code-scanning/2)

To fix the problem, you should add an explicit `permissions` block limiting the permissions of the GITHUB_TOKEN, which will restrict workflows and jobs to only the least privileges necessary. The recommended minimum is `contents: read`, as the workflow simply checks out code and does not require any write access to the repo. Place the `permissions:` block at the top level (right below `name:`), or inside the `jobs.lint-and-test:` job (either is sufficient in this simple workflow). The top-level block will apply to all jobs in the workflow. No existing imports or steps need changing.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
